### PR TITLE
Update IS operator from `=` to `IS`

### DIFF
--- a/dialect/sqlserver/sqlserver.go
+++ b/dialect/sqlserver/sqlserver.go
@@ -42,7 +42,7 @@ func DialectOptions() *goqu.SQLDialectOptions {
 		exp.LteOp:            []byte("<="),
 		exp.InOp:             []byte("IN"),
 		exp.NotInOp:          []byte("NOT IN"),
-		exp.IsOp:             []byte("="),
+		exp.IsOp:             []byte("IS"),
 		exp.IsNotOp:          []byte("IS NOT"),
 		exp.LikeOp:           []byte("LIKE"),
 		exp.NotLikeOp:        []byte("NOT LIKE"),


### PR DESCRIPTION
Fix for mssql not being able to get any rows from query