### PR TITLE
Add subquery flag to add OFFSET for ORDER BY in subquery

### DIFF
--- a/exp/select_clauses.go
+++ b/exp/select_clauses.go
@@ -59,6 +59,9 @@ type (
 		CommonTables() []CommonTableExpression
 		CommonTablesAppend(cte CommonTableExpression) SelectClauses
 
+		SetSubQuery(subQuery bool) SelectClauses
+		IsSubQuery() bool
+
 		Windows() []WindowExpression
 		SetWindows(ws []WindowExpression) SelectClauses
 		WindowsAppend(ws ...WindowExpression) SelectClauses
@@ -80,6 +83,7 @@ type (
 		compounds     []CompoundExpression
 		lock          Lock
 		windows       []WindowExpression
+		subQuery      bool
 	}
 )
 
@@ -123,6 +127,7 @@ func (c *selectClauses) clone() *selectClauses {
 		compounds:     c.compounds,
 		lock:          c.lock,
 		windows:       c.windows,
+		subQuery:      c.subQuery,
 	}
 }
 
@@ -133,6 +138,16 @@ func (c *selectClauses) CommonTablesAppend(cte CommonTableExpression) SelectClau
 	ret := c.clone()
 	ret.commonTables = append(ret.commonTables, cte)
 	return ret
+}
+
+func (c *selectClauses) SetSubQuery(subQuery bool) SelectClauses {
+	ret := c.clone()
+	ret.subQuery = subQuery
+	return ret
+}
+
+func (c *selectClauses) IsSubQuery() bool {
+	return c.subQuery
 }
 
 func (c *selectClauses) Select() ColumnListExpression {

--- a/select_dataset.go
+++ b/select_dataset.go
@@ -185,6 +185,10 @@ func (sd *SelectDataset) Truncate() *TruncateDataset {
 //
 // The name will refer to the results of the specified subquery.
 func (sd *SelectDataset) With(name string, subquery exp.Expression) *SelectDataset {
+	if subQuerySelectDataset, ok := subquery.(*SelectDataset); ok {
+		subquery = subQuerySelectDataset.copy(subQuerySelectDataset.clauses.SetSubQuery(true))
+	}
+
 	return sd.copy(sd.clauses.CommonTablesAppend(exp.NewCommonTableExpression(false, name, subquery)))
 }
 
@@ -490,7 +494,7 @@ func (sd *SelectDataset) CompoundFromSelf() *SelectDataset {
 
 // Sets the alias for this dataset. This is typically used when using a Dataset as a subselect. See examples.
 func (sd *SelectDataset) As(alias string) *SelectDataset {
-	return sd.copy(sd.clauses.SetAlias(T(alias)))
+	return sd.copy(sd.clauses.SetAlias(T(alias)).SetSubQuery(true))
 }
 
 // Returns the alias value as an identiier expression

--- a/sqlgen/common_sql_generator.go
+++ b/sqlgen/common_sql_generator.go
@@ -81,21 +81,23 @@ func (csg *commonSQLGenerator) OrderWithOffsetFetchSQL(
 	order exp.ColumnListExpression,
 	offset uint,
 	limit interface{},
+	subQuery bool,
 ) {
 	if order == nil {
 		return
 	}
 
 	csg.OrderSQL(b, order)
+	if offset > 0 || subQuery {
+		b.Write(csg.dialectOptions.OffsetFragment)
+		csg.esg.Generate(b, offset)
+		b.Write([]byte(" ROWS"))
 
-	b.Write(csg.dialectOptions.OffsetFragment)
-	csg.esg.Generate(b, offset)
-	b.Write([]byte(" ROWS"))
-
-	if limit != nil {
-		b.Write(csg.dialectOptions.FetchFragment)
-		csg.esg.Generate(b, limit)
-		b.Write([]byte(" ROWS ONLY"))
+		if limit != nil {
+			b.Write(csg.dialectOptions.FetchFragment)
+			csg.esg.Generate(b, limit)
+			b.Write([]byte(" ROWS ONLY"))
+		}
 	}
 }
 

--- a/sqlgen/select_sql_generator.go
+++ b/sqlgen/select_sql_generator.go
@@ -75,7 +75,7 @@ func (ssg *selectSQLGenerator) Generate(b sb.SQLBuilder, clauses exp.SelectClaus
 		case OrderSQLFragment:
 			ssg.OrderSQL(b, clauses.Order())
 		case OrderWithOffsetFetchSQLFragment:
-			ssg.OrderWithOffsetFetchSQL(b, clauses.Order(), clauses.Offset(), clauses.Limit())
+			ssg.OrderWithOffsetFetchSQL(b, clauses.Order(), clauses.Offset(), clauses.Limit(), clauses.IsSubQuery())
 		case LimitSQLFragment:
 			ssg.LimitSQL(b, clauses.Limit())
 		case OffsetSQLFragment:
@@ -135,7 +135,7 @@ func (ssg *selectSQLGenerator) SelectWithLimitSQL(b sb.SQLBuilder, clauses exp.S
 	if dc != nil {
 		b.Write(ssg.dialectOptions.DistinctFragment)
 	}
-	if clauses.Offset() == 0 && clauses.Limit() != nil {
+	if clauses.Offset() == 0 && clauses.Limit() != nil && !clauses.IsSubQuery() {
 		ssg.LimitSQL(b, clauses.Limit())
 		b.WriteRunes(ssg.dialectOptions.SpaceRune)
 	}


### PR DESCRIPTION
Because in previous PR, OFFSET is always used. 
But OFFSET cannot be used with TOP (SELECT TOP ...) (see https://stackoverflow.com/a/10639172)
This ensures SELECT TOP is never used and limit is done using FETCH 